### PR TITLE
サンプルの不要なインデントを削除

### DIFF
--- a/seiko.smartcs/README.md
+++ b/seiko.smartcs/README.md
@@ -66,20 +66,20 @@ The following example task login to the console port of the network device via C
 
 ```yaml
 ---
-  - name: Login to Network Device via Console Server SmartCS and execute "show version"
-    seiko.smartcs.smartcs_tty_command:
-      tty: 1
-      cmd_timeout : 5
-      recvchar:
-      - 'login: '
-      - 'Password: '
-      - 'SWITCH> '
-      sendchar:
-      - __NL__
-      - user1
-      - secret
-      - show version
-      - exit
+- name: Login to Network Device via Console Server SmartCS and execute "show version"
+  seiko.smartcs.smartcs_tty_command:
+    tty: 1
+    cmd_timeout : 5
+    recvchar:
+    - 'login: '
+    - 'Password: '
+    - 'SWITCH> '
+    sendchar:
+    - __NL__
+    - user1
+    - secret
+    - show version
+    - exit
 ```
 
 


### PR DESCRIPTION
`README.md` の `seiko.smartcs.smartcs_tty_command` モジュールを利用したサンプルを
各モジュールのページの [Examples](https://github.com/ssol-smartcs/ansible-collections/blob/main/seiko.smartcs/docs/seiko.smartcs.smartcs_command_module.rst#examples)と同様のインデントレベルに修正しました。